### PR TITLE
Update Pipfile for scikit-learn

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ pylint = "*"
 
 [packages]
 pandas = "*"
-sklearn = "*"
+scikit-learn = "*"
 scipy = "*"
 numpy = "*"
 cython = "*"


### PR DESCRIPTION
To address the pip install textpack error:

```
error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
```